### PR TITLE
Update bot icon image path URL

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -52,7 +52,7 @@
     "appIconUrl": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "https://github.com/OfficeDev/microsoft-teams-apps-openbadges/master/Manifest/color.png",
+      "defaultValue": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-apps-openbadges/master/Manifest/color.png",
       "metadata": {
         "description": "The link to the icon for the app. It must resolve to a PNG file."
       }


### PR DESCRIPTION
ARM deployment template is updated to get bot icon image from /Manifest folder. 