### PR TITLE
Pagination for getting members using Bot API

### DIFF
--- a/Source/Microsoft.Teams.App.Badges/Controllers/BadgeController.cs
+++ b/Source/Microsoft.Teams.App.Badges/Controllers/BadgeController.cs
@@ -96,6 +96,11 @@ namespace Microsoft.Teams.App.Badges.Controllers
         private readonly IBadgrUserHelper badgrUserHelper;
 
         /// <summary>
+        /// Helper to get cached team users information.
+        /// </summary>
+        private readonly TeamMemberCacheHelper teamMemberCacheHelper;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BadgeController"/> class.
         /// </summary>
         /// <param name="botAdapter">Open badges bot adapter.</param>
@@ -108,6 +113,7 @@ namespace Microsoft.Teams.App.Badges.Controllers
         /// <param name="badgeIssuerHelper">Instance of badge Issuer helper.</param>
         /// <param name="badgrApiHelper">Helper to handle errors and get user details.</param>
         /// <param name="badgrUserHelper">Helper to get user details from Badgr.</param>
+        /// <param name="teamMemberCacheHelper">Helper to get team users information.</param>
         public BadgeController(
             BotFrameworkAdapter botAdapter,
             IBadgrUserHelper badgeUserHelper,
@@ -118,7 +124,8 @@ namespace Microsoft.Teams.App.Badges.Controllers
             IKeyVaultHelper keyVaultHelper,
             IBadgrIssuerHelper badgeIssuerHelper,
             IBadgrApiHelper badgrApiHelper,
-            IBadgrUserHelper badgrUserHelper)
+            IBadgrUserHelper badgrUserHelper,
+            TeamMemberCacheHelper teamMemberCacheHelper)
         {
             this.badgeUserHelper = badgeUserHelper;
             this.logger = logger;
@@ -140,6 +147,7 @@ namespace Microsoft.Teams.App.Badges.Controllers
             this.badgeIssuerHelper = badgeIssuerHelper;
             this.badgrApiHelper = badgrApiHelper;
             this.badgrUserHelper = badgrUserHelper;
+            this.teamMemberCacheHelper = teamMemberCacheHelper;
         }
 
         /// <summary>
@@ -159,7 +167,7 @@ namespace Microsoft.Teams.App.Badges.Controllers
 
                 var userClaims = this.GetUserClaims();
 
-                IEnumerable<TeamsChannelAccount> teamsChannelAccounts = new List<TeamsChannelAccount>();
+                var teamsChannelAccounts = new List<TeamsChannelAccount>();
                 var conversationReference = new ConversationReference
                 {
                     ChannelId = teamId,
@@ -171,7 +179,7 @@ namespace Microsoft.Teams.App.Badges.Controllers
                     conversationReference,
                     async (context, token) =>
                     {
-                        teamsChannelAccounts = await TeamsInfo.GetTeamMembersAsync(context, teamId, default);
+                        var teamsChannelAccounts = await this.teamMemberCacheHelper.GetTeamMembersInfoAsync(context, teamId, token);
                     },
                     default);
 

--- a/Source/Microsoft.Teams.App.Badges/Helpers/Interfaces/ITeamMemberCacheHelper.cs
+++ b/Source/Microsoft.Teams.App.Badges/Helpers/Interfaces/ITeamMemberCacheHelper.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="ITeamMemberCacheHelper.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Microsoft.Teams.Apps.Scrum.Common
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Teams.App.Badges.Models;
+
+    /// <summary>
+    /// Interface cache for storing team members information.
+    /// </summary>
+    public interface ITeamMemberCacheHelper
+    {
+        /// <summary>
+        /// Provide team members information.
+        /// </summary>
+        /// <param name="turnContext">Provides context for a turn of a bot.</param>
+        /// <param name="teamId">Describes a team Id.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        /// <returns>Returns team members information from cache.</returns>
+        Task<List<TeamsUserInfo>> GetTeamMembersInfoAsync(ITurnContext turnContext, string teamId, CancellationToken cancellationToken);
+    }
+}

--- a/Source/Microsoft.Teams.App.Badges/Helpers/TeamMemberCacheHelper.cs
+++ b/Source/Microsoft.Teams.App.Badges/Helpers/TeamMemberCacheHelper.cs
@@ -1,0 +1,79 @@
+﻿// <copyright file="TeamMemberCacheHelper.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Microsoft.Teams.App.Badges.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Builder.Teams;
+    using Microsoft.Bot.Schema;
+    using Microsoft.Bot.Schema.Teams;
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Teams.App.Badges.Models;
+    using Microsoft.Teams.Apps.Scrum.Common;
+
+    /// <summary>
+    /// Implements team member cache.
+    /// </summary>
+    public class TeamMemberCacheHelper : ITeamMemberCacheHelper
+    {
+        /// <summary>
+        /// Sets the team members cache key.
+        /// </summary>
+        private const string TeamMembersCacheKey = "teamMembersCacheKey";
+
+        /// <summary>
+        /// Cache for storing teamMembers information.
+        /// </summary>
+        private readonly IMemoryCache memoryCache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamMemberCacheHelper"/> class.
+        /// </summary>
+        /// <param name="memoryCache">MemoryCache instance for caching authorization result.</param>
+        public TeamMemberCacheHelper(IMemoryCache memoryCache)
+        {
+            this.memoryCache = memoryCache;
+        }
+
+        /// <summary>
+        /// Provide team members information.
+        /// </summary>
+        /// <param name="turnContext">Provides context for a turn of a bot.</param>
+        /// <param name="teamId">Describes a team Id.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        /// <returns>Returns team members information from cache.</returns>
+        public async Task<List<TeamsUserInfo>> GetTeamMembersInfoAsync(ITurnContext turnContext, string teamId, CancellationToken cancellationToken)
+        {
+            string continuationToken = null;
+            bool isCacheEntryExists = this.memoryCache.TryGetValue(TeamMembersCacheKey + teamId, out List<TeamsUserInfo> channelMembers);
+            if (!isCacheEntryExists)
+            {
+                if (channelMembers == null)
+                {
+                    channelMembers = new List<TeamsUserInfo>();
+                }
+
+                do
+                {
+                    var currentPage = await TeamsInfo.GetPagedTeamMembersAsync(turnContext, teamId, continuationToken, pageSize: 500, cancellationToken);
+                    continuationToken = currentPage.ContinuationToken;
+                    channelMembers.AddRange(currentPage.Members.Select(member => new TeamsUserInfo { AadObjectId = member.AadObjectId, Email = member.Email, Id = member.Id, Name = member.Name }));
+                }
+                while (continuationToken != null && channelMembers.Count > 0);
+            }
+
+            if (channelMembers.Count > 0)
+            {
+                this.memoryCache.Set(TeamMembersCacheKey, channelMembers, TimeSpan.FromHours(1));
+            }
+
+            return channelMembers;
+        }
+    }
+}

--- a/Source/Microsoft.Teams.App.Badges/Microsoft.Teams.App.Badges.csproj
+++ b/Source/Microsoft.Teams.App.Badges/Microsoft.Teams.App.Badges.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Azure" Version="4.2.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.6.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.10" />
     <PackageReference Include="Polly" Version="7.2.0" />

--- a/Source/Microsoft.Teams.App.Badges/Models/TeamsUserInfo.cs
+++ b/Source/Microsoft.Teams.App.Badges/Models/TeamsUserInfo.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="TeamsUserInfo.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Microsoft.Teams.App.Badges.Models
+{
+    /// <summary>
+    /// Claims which are added in JWT token.
+    /// </summary>
+    public class TeamsUserInfo
+    {
+        /// <summary>
+        /// Gets or sets user Azure Active Directory object Id.
+        /// </summary>
+        public string AadObjectId { get; set; }
+
+        /// <summary>
+        /// Gets or sets channel id for the user or bot on this channel (Example: joe@smith.com, or @joesmith or 123456).
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets email Id of the user.
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Gets or sets display friendly name.
+        /// </summary>
+        public string Name { get; set; }
+    }
+}

--- a/Source/Microsoft.Teams.App.Badges/ServicesExtension.cs
+++ b/Source/Microsoft.Teams.App.Badges/ServicesExtension.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Teams.App.Badges
     using Microsoft.Teams.App.Badges.Helpers;
     using Microsoft.Teams.App.Badges.Helpers.DelegatingHandlers;
     using Microsoft.Teams.App.Badges.Models;
+    using Microsoft.Teams.Apps.Scrum.Common;
     using Polly;
     using Polly.Extensions.Http;
 
@@ -63,6 +64,7 @@ namespace Microsoft.Teams.App.Badges
             services.AddTransient<IKeyVaultHelper, KeyVaultHelper>();
             services.AddSingleton<ITokenHelper, TokenHelper>();
             services.AddSingleton<IKeyVaultClient>(new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(new AzureServiceTokenProvider().KeyVaultTokenCallback)));
+            services.AddSingleton<ITeamMemberCacheHelper, TeamMemberCacheHelper>();
         }
 
         /// <summary>

--- a/Source/Microsoft.Teams.App.Badges/Startup.cs
+++ b/Source/Microsoft.Teams.App.Badges/Startup.cs
@@ -73,6 +73,8 @@ namespace Microsoft.Teams.App.Badges
             services.AddSingleton(provider => new OAuthClient((MicrosoftAppCredentials)provider.GetService(typeof(MicrosoftAppCredentials))));
 
             services.AddTransient(serviceProvider => (BotFrameworkAdapter)serviceProvider.GetRequiredService<IBotFrameworkHttpAdapter>());
+
+            services.AddMemoryCache();
         }
 
         /// <summary>


### PR DESCRIPTION
**Issue details** -
TeamsInfo.GetMembersAsync method to retrieve information for one or more members of a chat has been deprecated.

**Solution details** -
Changed GetTeamMembersAsync implementation with GetPagedTeamMembers to get a paginated list of members of a team.
Added TeamsUserInfo model to get necessary info about user details which is required.
Added caching to cache Team users information

**Testing done** -
Verified member details getting retrieved.
Verified locally and ARM deployment.